### PR TITLE
ci(dictionary): Add `python-common` dictionary

### DIFF
--- a/.dictionary.txt
+++ b/.dictionary.txt
@@ -1,2 +1,1 @@
 Laven
-setuptools

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -11,3 +11,4 @@ dictionaries:
   - fullstack
   - npm
   - python
+  - python-common


### PR DESCRIPTION
Add `python-common` dictionary, which contains "setuptools", to CSpell config. Remove "setuptools" from `custom` dictionary.