### PR TITLE
chore(Commitizen): Don't bump major version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "poetry.core.masonry.api"
   [tool.commitizen]
   version = "0.0.0"
   version_files = ["pyproject.toml:version"]
+  major_version_zero = true
 
   [tool.poetry]
   name = "Template Repo"


### PR DESCRIPTION
Normally, Commitizen, in compliance with semantic versioning, bumps the project's major version on breaking changes. At major version 0, any release can have breaking changes, and bumping the major version to 1 signifies the stability of the public API. Since this is a template repository, configure Commitizen not to bump the major version on breaking changes since projects typically start at major version 0.