### PR TITLE
chore(Lychee): Increase retry limit from 3 to 4

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -1,1 +1,2 @@
 exclude_mail = true
+max_retries = 4


### PR DESCRIPTION
The link checker Lychee was recently added to MegaLinter in v7.2.0. Increase its network request retry limit to avoid false positives.